### PR TITLE
Use kebab-case in test function names

### DIFF
--- a/t/02_null_main_ast.t
+++ b/t/02_null_main_ast.t
@@ -13,5 +13,5 @@ our $source = q<<<
 
 {
     my $ast = C::Parser.parse($source);
-    isa_ok($ast, C::AST::TransUnit, 'gives a C::AST::TransUnit');
+    isa-ok($ast, C::AST::TransUnit, 'gives a C::AST::TransUnit');
 }

--- a/t/04_hello_ast.t
+++ b/t/04_hello_ast.t
@@ -14,5 +14,5 @@ our $source = q<<<
 
 {
     my $ast = C::Parser.parse($source);
-    isa_ok($ast, C::AST::TransUnit, 'gives a C::AST::TransUnit');
+    isa-ok($ast, C::AST::TransUnit, 'gives a C::AST::TransUnit');
 }

--- a/t/05_modern.t
+++ b/t/05_modern.t
@@ -16,5 +16,5 @@ our $source = q<<<
 
 {
     my $match = C::Parser.parse($source);
-    isa_ok($match, C::AST::TransUnit, 'gives a TransUnit');
+    isa-ok($match, C::AST::TransUnit, 'gives a TransUnit');
 }

--- a/t/06_ancient.t
+++ b/t/06_ancient.t
@@ -18,5 +18,5 @@ our $source = q<<<
 
 {
     my $match = C::Parser.parse($source);
-    isa_ok($match, C::AST::TransUnit, 'gives a C::AST::TransUnit');
+    isa-ok($match, C::AST::TransUnit, 'gives a C::AST::TransUnit');
 }

--- a/t/07_mbstate.t
+++ b/t/07_mbstate.t
@@ -13,5 +13,5 @@ our $source = q<<<
 
 {
     my $ast = C::Parser.parse($source);
-    isa_ok($ast, C::AST::TransUnit, 'gives a C::AST::TransUnit');
+    isa-ok($ast, C::AST::TransUnit, 'gives a C::AST::TransUnit');
 }

--- a/t/08_fgetc.t
+++ b/t/08_fgetc.t
@@ -12,5 +12,5 @@ our $source = q<<<
 
 {
     my $ast = C::Parser.parse($source);
-    isa_ok($ast, C::AST::TransUnit, 'gives a C::AST::TransUnit');
+    isa-ok($ast, C::AST::TransUnit, 'gives a C::AST::TransUnit');
 }

--- a/t/primary_lex.t
+++ b/t/primary_lex.t
@@ -7,19 +7,19 @@ use C::Parser::Lexer;
 {
     my $source = q<<< char newline = '\n'; >>>;
     my $ast = C::Parser::Lexer.parse($source);
-    isa_ok $ast, Match, 'gives a Match';
+    isa-ok $ast, Match, 'gives a Match';
 }
 
 {
     my $source = q<<< char *name = "world"; >>>;
     my $ast = C::Parser::Lexer.parse($source);
-    isa_ok $ast, Match, 'gives a Match';
+    isa-ok $ast, Match, 'gives a Match';
 }
 
 {
     my $source = q<<< int number = 5; >>>;
     my $ast = C::Parser::Lexer.parse($source);
-    isa_ok $ast, Match, 'gives a Match';
+    isa-ok $ast, Match, 'gives a Match';
 
     #my @tokens = $ast{'c-tokens'}{'c-token'};
     #say @tokens.perl;
@@ -34,5 +34,5 @@ use C::Parser::Lexer;
 {
     my $source = q<<< double pi64 = 3.14; >>>;
     my $ast = C::Parser::Lexer.parse($source);
-    isa_ok $ast, Match, 'gives a Match';
+    isa-ok $ast, Match, 'gives a Match';
 }


### PR DESCRIPTION
Test function names with underscores have been deprecated in favour of their
kebab-case variants.  The deprecated form will be removed in Rakudo 2015.09.
This change brings the test suite up to date with current Rakudo.
