### PR TITLE
Updates for christmas release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ nytprof.out
 *.bs
 *~
 .DS_Store
+.precomp

--- a/lib/C/Parser/Actions.pm6
+++ b/lib/C/Parser/Actions.pm6
@@ -613,7 +613,7 @@ method specifier-qualifier-list($/) {
     my @specs = @quals.grep({$_.WHAT === Spec});
     @specs = C::AST::Specs.new(children => @specs);
     my @children = @quals.grep({$_.WHAT !=== Spec});
-    @children.unshift(@specs);
+    @children.prepend(@specs);
     my $op = TyKind::specifier_qualifier_list;
     make C::AST::TypeOp.new(:$op, :@children);
 }

--- a/lib/C/Parser/Grammar.pm6
+++ b/lib/C/Parser/Grammar.pm6
@@ -940,7 +940,7 @@ rule translation-unit {
     :my %*ENUMS;
     :my %*STRUCTS;
     :my %*TYPEDEFS;
-    :my @*CONTEXTS = @();
+    :my @*CONTEXTS = ();
 
     # BUILTIN_TYPEDEFS never changes
     # maybe this could be const/final?


### PR DESCRIPTION
Hi,
This fixes two problems that it had with the 6.c release of rakudo.

unshift no longer flattens - use prepend instead with arrays
@() was causing an Any to be placed in the array.
