### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,5 +1,6 @@
 {
         "name" : "C::Parser",
+        "license" : "LGPL-3.0+",
         "version" : "0.2.5",
         "description" : "Grammar for Parsing C in Perl6",
         "author" : "Andrew Robbins",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license