### PR TITLE
Replace deprecated SPDX license identifier

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -2,7 +2,7 @@
         "perl" : "6.*",
         "name" : "C::Parser",
         "version" : "0.3.2",
-	"license" : "LGPL-3.0+",
+	"license" : "LGPL-3.0-or-later",
         "description" : "Grammar for Parsing C in Perl6",
         "author" : "Andrew Robbins",
         "build-depends" : [ ],


### PR DESCRIPTION
The `LGPL-3.0+` identifier has been deprecated in favour of `LGPL-3.0-or-later` as stated in https://spdx.org/licenses

This is preventing this module from being added to the ecosystem (see https://github.com/Raku/ecosystem/pull/567)